### PR TITLE
Fix report file names

### DIFF
--- a/build_report.py
+++ b/build_report.py
@@ -281,7 +281,7 @@ def main(days, tags, report_name):
             datetime.time(0, 0, 0),
         )
         days = to_date.strftime("%B, %Y")
-        file_name = f'{to_date.strftime("%B")}_pingdom_report.html'
+        file_name = f'{to_date.strftime("%Y_%m")}_pingdom_report.html'
     finally:
         unix_from_date = from_date.timestamp()
         unix_to_date = to_date.timestamp()


### PR DESCRIPTION
When running the report on the previous month, the script would generate a filename like "February_pingdom_report.html". That sorts poorly alphabetically and it means new reports stomp on reports from the previous year.

This changes the naming scheme to YYYY_MM_pingdom_report.html.